### PR TITLE
Link to Panagram slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 #### Katie Jenike, Sam Kovaka, Shujun Ou, Stephen Hwang, Srividya Ramakrishnan, Ben Langmead, Zach Lippman, Michael Schatz
 
 
-An alignment-free pan-genome viewer
+[An alignment-free pan-genome viewer](https://www.dropbox.com/s/g7snjgr8bs6c2uj/2023.01.17.Panagram.pdf)
 
 # Installation
 


### PR DESCRIPTION
When I first encountered this repo, I thought it looked quite interesting, but I wanted more context and visual examples.  Then I found slides [via Twitter](https://twitter.com/mike_schatz/status/1615440857980899328) at https://www.dropbox.com/s/g7snjgr8bs6c2uj/2023.01.17.Panagram.pdf -- exactly what I was looking for.

This links those slides from the README, so folks who find Panagram via GitHub can easily get a scientific overview.  It looks really slick, and useful!

P.S.: I see Panagram uses Dash.  If you ever want to discuss views like [Ideogram Dash](https://dash.plotly.com/dash-bio/ideogram), let me know!  My email is in my profile.  The [underlying library](https://eweitz.github.io/ideogram/) that I maintain supports any eukaryote with known chromosomes lengths.