### PR TITLE
Add simple github action to run linting and type checking with reasonable defaults

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,24 @@
+name: Python linting
+on: [push, pull_request]
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.12']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run linting
+        run: ruff check panagram
+      - name: Install mypy
+        run: pip install mypy
+      - name: Run type checking
+        run: mypy panagram
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+show_error_codes = True
+ignore_missing_imports = True
+pretty = True
+no_implicit_optional = True
+strict_equality = True
+warn_unreachable = True
+warn_unused_ignores = True
+check_untyped_defs = True


### PR DESCRIPTION
This runs ruff and mypy on the `panagram` directory. Both checks with fail miserably with a ton of errors. These can be addressed by (a) fixing the issue; (b) modifying the config for mypy or ruff to ignore certain types of errors; or (c) explicitly ignoring  individul errors.

(This will run under Python 3.8 and 3.12 - I'm guessing these are reasonable min/max versions?)